### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+PyQt5
+pycryptodomex
+paramiko
+requests
+password-strength
+Wand


### PR DESCRIPTION
This pull request adds a `requirements.txt` file for easy installing of requirements via `pip`.

The requirements were taken from the [wiki](https://github.com/bruot/pyrmexplorer/wiki#method-2-run-source-with-python-3). Specific version requirements were omitted as they are not specified in the wiki either.